### PR TITLE
feat:Add emotions array property to ultravox.v1.CartesiaVoice schema

### DIFF
--- a/src/libs/Ultravox/Generated/Ultravox.Models.UltravoxV1CartesiaVoice.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.Models.UltravoxV1CartesiaVoice.g.cs
@@ -34,6 +34,12 @@ namespace Ultravox
         public string? Emotion { get; set; }
 
         /// <summary>
+        /// See https://docs.cartesia.ai/api-reference/tts/tts#send.Generation%20Request.voice.Ttsrequest%20ID%20Specifier.__experimental_controls.emotion
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("emotions")]
+        public global::System.Collections.Generic.IList<string>? Emotions { get; set; }
+
+        /// <summary>
         /// Additional properties that are not explicitly defined in the schema
         /// </summary>
         [global::System.Text.Json.Serialization.JsonExtensionData]
@@ -55,6 +61,9 @@ namespace Ultravox
         /// <param name="emotion">
         /// See https://docs.cartesia.ai/api-reference/tts/tts#send.Generation%20Request.voice.Ttsrequest%20ID%20Specifier.__experimental_controls.emotion
         /// </param>
+        /// <param name="emotions">
+        /// See https://docs.cartesia.ai/api-reference/tts/tts#send.Generation%20Request.voice.Ttsrequest%20ID%20Specifier.__experimental_controls.emotion
+        /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
@@ -62,12 +71,14 @@ namespace Ultravox
             string? voiceId,
             string? model,
             float? speed,
-            string? emotion)
+            string? emotion,
+            global::System.Collections.Generic.IList<string>? emotions)
         {
             this.VoiceId = voiceId;
             this.Model = model;
             this.Speed = speed;
             this.Emotion = emotion;
+            this.Emotions = emotions;
         }
 
         /// <summary>

--- a/src/libs/Ultravox/openapi.yaml
+++ b/src/libs/Ultravox/openapi.yaml
@@ -3455,6 +3455,11 @@ components:
         emotion:
           type: string
           description: See https://docs.cartesia.ai/api-reference/tts/tts#send.Generation%20Request.voice.Ttsrequest%20ID%20Specifier.__experimental_controls.emotion
+        emotions:
+          type: array
+          items:
+            type: string
+          description: See https://docs.cartesia.ai/api-reference/tts/tts#send.Generation%20Request.voice.Ttsrequest%20ID%20Specifier.__experimental_controls.emotion
       description: Specification for a voice served by Cartesia.
     ultravox.v1.ClientCallToolDetails:
       type: object


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for an `emotions` property, allowing multiple emotions to be specified for voices in the Cartesia Voice schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->