### PR TITLE
feat:Add optional primaryLanguage property and update previewUrl in Voice schemas

### DIFF
--- a/src/libs/Ultravox/Generated/Ultravox.IVoicesClient.PreviewVoice.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.IVoicesClient.PreviewVoice.g.cs
@@ -19,6 +19,9 @@ namespace Ultravox
         /// </summary>
         /// <param name="name"></param>
         /// <param name="description"></param>
+        /// <param name="primaryLanguage">
+        /// BCP47 language code for the primary language supported by this voice.
+        /// </param>
         /// <param name="definition">
         /// A voice not known to Ultravox Realtime that can nonetheless be used for a call.<br/>
         ///  Such voices are significantly less validated than normal voices and you'll be<br/>
@@ -31,6 +34,7 @@ namespace Ultravox
             string name,
             global::Ultravox.UltravoxV1ExternalVoice definition,
             string? description = default,
+            string? primaryLanguage = default,
             global::System.Threading.CancellationToken cancellationToken = default);
     }
 }

--- a/src/libs/Ultravox/Generated/Ultravox.IVoicesClient.VoicesPartialUpdate.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.IVoicesClient.VoicesPartialUpdate.g.cs
@@ -22,6 +22,9 @@ namespace Ultravox
         /// <param name="voiceId"></param>
         /// <param name="name"></param>
         /// <param name="description"></param>
+        /// <param name="primaryLanguage">
+        /// BCP47 language code for the primary language supported by this voice.
+        /// </param>
         /// <param name="definition">
         /// A voice not known to Ultravox Realtime that can nonetheless be used for a call.<br/>
         ///  Such voices are significantly less validated than normal voices and you'll be<br/>
@@ -34,6 +37,7 @@ namespace Ultravox
             global::System.Guid voiceId,
             string? name = default,
             string? description = default,
+            string? primaryLanguage = default,
             global::Ultravox.UltravoxV1ExternalVoice? definition = default,
             global::System.Threading.CancellationToken cancellationToken = default);
     }

--- a/src/libs/Ultravox/Generated/Ultravox.IVoicesClient.VoicesUpdate.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.IVoicesClient.VoicesUpdate.g.cs
@@ -22,6 +22,9 @@ namespace Ultravox
         /// <param name="voiceId"></param>
         /// <param name="name"></param>
         /// <param name="description"></param>
+        /// <param name="primaryLanguage">
+        /// BCP47 language code for the primary language supported by this voice.
+        /// </param>
         /// <param name="definition">
         /// A voice not known to Ultravox Realtime that can nonetheless be used for a call.<br/>
         ///  Such voices are significantly less validated than normal voices and you'll be<br/>
@@ -35,6 +38,7 @@ namespace Ultravox
             string name,
             global::Ultravox.UltravoxV1ExternalVoice definition,
             string? description = default,
+            string? primaryLanguage = default,
             global::System.Threading.CancellationToken cancellationToken = default);
     }
 }

--- a/src/libs/Ultravox/Generated/Ultravox.Models.PatchedVoice.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.Models.PatchedVoice.g.cs
@@ -27,6 +27,12 @@ namespace Ultravox
         public string? Description { get; set; }
 
         /// <summary>
+        /// BCP47 language code for the primary language supported by this voice.
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("primaryLanguage")]
+        public string? PrimaryLanguage { get; set; }
+
+        /// <summary>
         /// Included only in responses
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("previewUrl")]
@@ -72,6 +78,9 @@ namespace Ultravox
         /// </param>
         /// <param name="name"></param>
         /// <param name="description"></param>
+        /// <param name="primaryLanguage">
+        /// BCP47 language code for the primary language supported by this voice.
+        /// </param>
         /// <param name="previewUrl">
         /// Included only in responses
         /// </param>
@@ -97,6 +106,7 @@ namespace Ultravox
             global::System.Guid? voiceId,
             string? name,
             string? description,
+            string? primaryLanguage,
             string? previewUrl,
             global::Ultravox.OwnershipEnum? ownership,
             global::Ultravox.BillingStyleEnum? billingStyle,
@@ -105,6 +115,7 @@ namespace Ultravox
             this.VoiceId = voiceId;
             this.Name = name;
             this.Description = description;
+            this.PrimaryLanguage = primaryLanguage;
             this.PreviewUrl = previewUrl;
             this.Ownership = ownership;
             this.BillingStyle = billingStyle;

--- a/src/libs/Ultravox/Generated/Ultravox.Models.Voice.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.Models.Voice.g.cs
@@ -29,10 +29,17 @@ namespace Ultravox
         public string? Description { get; set; }
 
         /// <summary>
+        /// BCP47 language code for the primary language supported by this voice.
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("primaryLanguage")]
+        public string? PrimaryLanguage { get; set; }
+
+        /// <summary>
         /// Included only in responses
         /// </summary>
+        /// <default>default!</default>
         [global::System.Text.Json.Serialization.JsonPropertyName("previewUrl")]
-        public string? PreviewUrl { get; set; }
+        public string PreviewUrl { get; set; } = default!;
 
         /// <summary>
         /// Included only in responses
@@ -77,6 +84,9 @@ namespace Ultravox
         /// </param>
         /// <param name="name"></param>
         /// <param name="description"></param>
+        /// <param name="primaryLanguage">
+        /// BCP47 language code for the primary language supported by this voice.
+        /// </param>
         /// <param name="previewUrl">
         /// Included only in responses
         /// </param>
@@ -102,8 +112,9 @@ namespace Ultravox
             string name,
             global::Ultravox.UltravoxV1ExternalVoice definition,
             string? description,
-            string? previewUrl,
+            string? primaryLanguage,
             global::System.Guid voiceId = default!,
+            string previewUrl = default!,
             global::Ultravox.OwnershipEnum ownership = default!,
             global::Ultravox.BillingStyleEnum billingStyle = default!)
         {
@@ -111,6 +122,7 @@ namespace Ultravox
             this.Definition = definition ?? throw new global::System.ArgumentNullException(nameof(definition));
             this.VoiceId = voiceId;
             this.Description = description;
+            this.PrimaryLanguage = primaryLanguage;
             this.PreviewUrl = previewUrl;
             this.Ownership = ownership;
             this.BillingStyle = billingStyle;

--- a/src/libs/Ultravox/Generated/Ultravox.VoicesClient.PreviewVoice.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.VoicesClient.PreviewVoice.g.cs
@@ -207,6 +207,9 @@ namespace Ultravox
         /// </summary>
         /// <param name="name"></param>
         /// <param name="description"></param>
+        /// <param name="primaryLanguage">
+        /// BCP47 language code for the primary language supported by this voice.
+        /// </param>
         /// <param name="definition">
         /// A voice not known to Ultravox Realtime that can nonetheless be used for a call.<br/>
         ///  Such voices are significantly less validated than normal voices and you'll be<br/>
@@ -219,12 +222,14 @@ namespace Ultravox
             string name,
             global::Ultravox.UltravoxV1ExternalVoice definition,
             string? description = default,
+            string? primaryLanguage = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             var __request = new global::Ultravox.Voice
             {
                 Name = name,
                 Description = description,
+                PrimaryLanguage = primaryLanguage,
                 Definition = definition,
             };
 

--- a/src/libs/Ultravox/Generated/Ultravox.VoicesClient.VoicesPartialUpdate.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.VoicesClient.VoicesPartialUpdate.g.cs
@@ -177,6 +177,9 @@ namespace Ultravox
         /// <param name="voiceId"></param>
         /// <param name="name"></param>
         /// <param name="description"></param>
+        /// <param name="primaryLanguage">
+        /// BCP47 language code for the primary language supported by this voice.
+        /// </param>
         /// <param name="definition">
         /// A voice not known to Ultravox Realtime that can nonetheless be used for a call.<br/>
         ///  Such voices are significantly less validated than normal voices and you'll be<br/>
@@ -189,6 +192,7 @@ namespace Ultravox
             global::System.Guid voiceId,
             string? name = default,
             string? description = default,
+            string? primaryLanguage = default,
             global::Ultravox.UltravoxV1ExternalVoice? definition = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
@@ -196,6 +200,7 @@ namespace Ultravox
             {
                 Name = name,
                 Description = description,
+                PrimaryLanguage = primaryLanguage,
                 Definition = definition,
             };
 

--- a/src/libs/Ultravox/Generated/Ultravox.VoicesClient.VoicesUpdate.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.VoicesClient.VoicesUpdate.g.cs
@@ -177,6 +177,9 @@ namespace Ultravox
         /// <param name="voiceId"></param>
         /// <param name="name"></param>
         /// <param name="description"></param>
+        /// <param name="primaryLanguage">
+        /// BCP47 language code for the primary language supported by this voice.
+        /// </param>
         /// <param name="definition">
         /// A voice not known to Ultravox Realtime that can nonetheless be used for a call.<br/>
         ///  Such voices are significantly less validated than normal voices and you'll be<br/>
@@ -190,12 +193,14 @@ namespace Ultravox
             string name,
             global::Ultravox.UltravoxV1ExternalVoice definition,
             string? description = default,
+            string? primaryLanguage = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             var __request = new global::Ultravox.Voice
             {
                 Name = name,
                 Description = description,
+                PrimaryLanguage = primaryLanguage,
                 Definition = definition,
             };
 

--- a/src/libs/Ultravox/openapi.yaml
+++ b/src/libs/Ultravox/openapi.yaml
@@ -3313,10 +3313,14 @@ components:
           maxLength: 240
           type: string
           nullable: true
+        primaryLanguage:
+          maxLength: 10
+          type: string
+          description: BCP47 language code for the primary language supported by this voice.
+          nullable: true
         previewUrl:
           type: string
           format: uri
-          nullable: true
           readOnly: true
         ownership:
           allOf:
@@ -3456,10 +3460,14 @@ components:
           maxLength: 240
           type: string
           nullable: true
+        primaryLanguage:
+          maxLength: 10
+          type: string
+          description: BCP47 language code for the primary language supported by this voice.
+          nullable: true
         previewUrl:
           type: string
           format: uri
-          nullable: true
           readOnly: true
         ownership:
           allOf:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional "primaryLanguage" field to voice-related API responses, allowing users to see the primary language supported by each voice.

* **Changes**
  * The "previewUrl" field in voice-related API responses is no longer marked as nullable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->