### PR TITLE
feat:Add optional primaryLanguage query parameter to GET /api/voices endpoint

### DIFF
--- a/src/libs/Ultravox/Generated/Ultravox.IVoicesClient.VoicesList.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.IVoicesClient.VoicesList.g.cs
@@ -11,6 +11,7 @@ namespace Ultravox
         /// <param name="cursor"></param>
         /// <param name="ownership"></param>
         /// <param name="pageSize"></param>
+        /// <param name="primaryLanguage"></param>
         /// <param name="search"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::Ultravox.ApiException"></exception>
@@ -19,6 +20,7 @@ namespace Ultravox
             string? cursor = default,
             global::Ultravox.VoicesListOwnership? ownership = default,
             int? pageSize = default,
+            string? primaryLanguage = default,
             string? search = default,
             global::System.Threading.CancellationToken cancellationToken = default);
     }

--- a/src/libs/Ultravox/Generated/Ultravox.VoicesClient.VoicesList.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.VoicesClient.VoicesList.g.cs
@@ -11,6 +11,7 @@ namespace Ultravox
             ref string? cursor,
             ref global::Ultravox.VoicesListOwnership? ownership,
             ref int? pageSize,
+            ref string? primaryLanguage,
             ref string? search);
         partial void PrepareVoicesListRequest(
             global::System.Net.Http.HttpClient httpClient,
@@ -19,6 +20,7 @@ namespace Ultravox
             string? cursor,
             global::Ultravox.VoicesListOwnership? ownership,
             int? pageSize,
+            string? primaryLanguage,
             string? search);
         partial void ProcessVoicesListResponse(
             global::System.Net.Http.HttpClient httpClient,
@@ -36,6 +38,7 @@ namespace Ultravox
         /// <param name="cursor"></param>
         /// <param name="ownership"></param>
         /// <param name="pageSize"></param>
+        /// <param name="primaryLanguage"></param>
         /// <param name="search"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::Ultravox.ApiException"></exception>
@@ -44,6 +47,7 @@ namespace Ultravox
             string? cursor = default,
             global::Ultravox.VoicesListOwnership? ownership = default,
             int? pageSize = default,
+            string? primaryLanguage = default,
             string? search = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
@@ -55,6 +59,7 @@ namespace Ultravox
                 cursor: ref cursor,
                 ownership: ref ownership,
                 pageSize: ref pageSize,
+                primaryLanguage: ref primaryLanguage,
                 search: ref search);
 
             var __pathBuilder = new global::Ultravox.PathBuilder(
@@ -65,6 +70,7 @@ namespace Ultravox
                 .AddOptionalParameter("cursor", cursor) 
                 .AddOptionalParameter("ownership", ownership?.ToValueString()) 
                 .AddOptionalParameter("pageSize", pageSize?.ToString()) 
+                .AddOptionalParameter("primaryLanguage", primaryLanguage) 
                 .AddOptionalParameter("search", search) 
                 ; 
             var __path = __pathBuilder.ToString();
@@ -102,6 +108,7 @@ namespace Ultravox
                 cursor: cursor,
                 ownership: ownership,
                 pageSize: pageSize,
+                primaryLanguage: primaryLanguage,
                 search: search);
 
             using var __response = await HttpClient.SendAsync(

--- a/src/libs/Ultravox/openapi.yaml
+++ b/src/libs/Ultravox/openapi.yaml
@@ -1830,6 +1830,12 @@ paths:
           description: Number of results to return per page.
           schema:
             type: integer
+        - name: primaryLanguage
+          in: query
+          description: 'The desired primary language for voice results using BCP47. Voices with different regions/scripts/variants but the same language tag may also be included but will be further down the results. If not provided, all languages are included.'
+          schema:
+            minLength: 1
+            type: string
         - name: search
           in: query
           description: The search string used to filter results.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an optional primary language filter when retrieving voices, allowing users to specify their preferred language for voice results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->