### PR TITLE
feat:Add required billedMinutes to CallStatistics and DailyCallStatistics

### DIFF
--- a/src/libs/Ultravox/Generated/Ultravox.Models.CallStatistics.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.Models.CallStatistics.g.cs
@@ -30,6 +30,13 @@ namespace Ultravox
         public required int JoinedCount { get; set; }
 
         /// <summary>
+        /// Total billed minutes.
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("billedMinutes")]
+        [global::System.Text.Json.Serialization.JsonRequired]
+        public required double BilledMinutes { get; set; }
+
+        /// <summary>
         /// Additional properties that are not explicitly defined in the schema
         /// </summary>
         [global::System.Text.Json.Serialization.JsonExtensionData]
@@ -47,17 +54,22 @@ namespace Ultravox
         /// <param name="joinedCount">
         /// Number of calls that were joined
         /// </param>
+        /// <param name="billedMinutes">
+        /// Total billed minutes.
+        /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
         public CallStatistics(
             int totalCount,
             string duration,
-            int joinedCount)
+            int joinedCount,
+            double billedMinutes)
         {
             this.TotalCount = totalCount;
             this.Duration = duration ?? throw new global::System.ArgumentNullException(nameof(duration));
             this.JoinedCount = joinedCount;
+            this.BilledMinutes = billedMinutes;
         }
 
         /// <summary>

--- a/src/libs/Ultravox/Generated/Ultravox.Models.DailyCallStatistics.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.Models.DailyCallStatistics.g.cs
@@ -30,6 +30,13 @@ namespace Ultravox
         public required int JoinedCount { get; set; }
 
         /// <summary>
+        /// Total billed minutes.
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("billedMinutes")]
+        [global::System.Text.Json.Serialization.JsonRequired]
+        public required double BilledMinutes { get; set; }
+
+        /// <summary>
         /// Date of usage
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("date")]
@@ -54,6 +61,9 @@ namespace Ultravox
         /// <param name="joinedCount">
         /// Number of calls that were joined
         /// </param>
+        /// <param name="billedMinutes">
+        /// Total billed minutes.
+        /// </param>
         /// <param name="date">
         /// Date of usage
         /// </param>
@@ -64,11 +74,13 @@ namespace Ultravox
             int totalCount,
             string duration,
             int joinedCount,
+            double billedMinutes,
             global::System.DateTime date)
         {
             this.TotalCount = totalCount;
             this.Duration = duration ?? throw new global::System.ArgumentNullException(nameof(duration));
             this.JoinedCount = joinedCount;
+            this.BilledMinutes = billedMinutes;
             this.Date = date;
         }
 

--- a/src/libs/Ultravox/openapi.yaml
+++ b/src/libs/Ultravox/openapi.yaml
@@ -2935,6 +2935,7 @@ components:
           description: The initial state of the call stage which is readable/writable by tools.
     CallStatistics:
       required:
+        - billedMinutes
         - duration
         - joinedCount
         - totalCount
@@ -2949,6 +2950,10 @@ components:
         joinedCount:
           type: integer
           description: Number of calls that were joined
+        billedMinutes:
+          type: number
+          description: Total billed minutes.
+          format: double
     CallTombstone:
       required:
         - accountId
@@ -3063,6 +3068,7 @@ components:
           format: uri
     DailyCallStatistics:
       required:
+        - billedMinutes
         - date
         - duration
         - joinedCount
@@ -3078,6 +3084,10 @@ components:
         joinedCount:
           type: integer
           description: Number of calls that were joined
+        billedMinutes:
+          type: number
+          description: Total billed minutes.
+          format: double
         date:
           type: string
           description: Date of usage


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Call and daily call statistics now include “billed minutes,” providing clearer billing insights across reports, dashboards, and exports.
  * API responses now return the billedMinutes value for each statistics record.

* **Chores**
  * Updated API schema to make billedMinutes a required field in CallStatistics and DailyCallStatistics. Clients using strict schemas may need to update integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->