### PR TITLE
feat:Add agentIds query to call GET endpoints and required agentId field

### DIFF
--- a/src/libs/Ultravox/Generated/Ultravox.AccountsClient.AccountsMeUsageCallsRetrieve.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.AccountsClient.AccountsMeUsageCallsRetrieve.g.cs
@@ -7,6 +7,7 @@ namespace Ultravox
     {
         partial void PrepareAccountsMeUsageCallsRetrieveArguments(
             global::System.Net.Http.HttpClient httpClient,
+            global::System.Collections.Generic.IList<global::System.Guid>? agentIds,
             ref string? durationMax,
             ref string? durationMin,
             ref global::System.DateTime? fromDate,
@@ -17,6 +18,7 @@ namespace Ultravox
         partial void PrepareAccountsMeUsageCallsRetrieveRequest(
             global::System.Net.Http.HttpClient httpClient,
             global::System.Net.Http.HttpRequestMessage httpRequestMessage,
+            global::System.Collections.Generic.IList<global::System.Guid>? agentIds,
             string? durationMax,
             string? durationMin,
             global::System.DateTime? fromDate,
@@ -36,6 +38,7 @@ namespace Ultravox
         /// <summary>
         /// Gets aggregated call usage.
         /// </summary>
+        /// <param name="agentIds"></param>
         /// <param name="durationMax"></param>
         /// <param name="durationMin"></param>
         /// <param name="fromDate"></param>
@@ -46,6 +49,7 @@ namespace Ultravox
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::Ultravox.ApiException"></exception>
         public async global::System.Threading.Tasks.Task<global::Ultravox.CallUsage> AccountsMeUsageCallsRetrieveAsync(
+            global::System.Collections.Generic.IList<global::System.Guid>? agentIds = default,
             string? durationMax = default,
             string? durationMin = default,
             global::System.DateTime? fromDate = default,
@@ -59,6 +63,7 @@ namespace Ultravox
                 client: HttpClient);
             PrepareAccountsMeUsageCallsRetrieveArguments(
                 httpClient: HttpClient,
+                agentIds: agentIds,
                 durationMax: ref durationMax,
                 durationMin: ref durationMin,
                 fromDate: ref fromDate,
@@ -71,6 +76,7 @@ namespace Ultravox
                 path: "/api/accounts/me/usage/calls",
                 baseUri: HttpClient.BaseAddress); 
             __pathBuilder 
+                .AddOptionalParameter("agentIds", agentIds, selector: static x => x.ToString(), delimiter: ",", explode: true) 
                 .AddOptionalParameter("durationMax", durationMax) 
                 .AddOptionalParameter("durationMin", durationMin) 
                 .AddOptionalParameter("fromDate", fromDate?.ToString("yyyy-MM-dd")) 
@@ -110,6 +116,7 @@ namespace Ultravox
             PrepareAccountsMeUsageCallsRetrieveRequest(
                 httpClient: HttpClient,
                 httpRequestMessage: __httpRequest,
+                agentIds: agentIds,
                 durationMax: durationMax,
                 durationMin: durationMin,
                 fromDate: fromDate,

--- a/src/libs/Ultravox/Generated/Ultravox.CallsClient.CallsList.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.CallsClient.CallsList.g.cs
@@ -7,6 +7,7 @@ namespace Ultravox
     {
         partial void PrepareCallsListArguments(
             global::System.Net.Http.HttpClient httpClient,
+            global::System.Collections.Generic.IList<global::System.Guid>? agentIds,
             ref string? cursor,
             ref string? durationMax,
             ref string? durationMin,
@@ -20,6 +21,7 @@ namespace Ultravox
         partial void PrepareCallsListRequest(
             global::System.Net.Http.HttpClient httpClient,
             global::System.Net.Http.HttpRequestMessage httpRequestMessage,
+            global::System.Collections.Generic.IList<global::System.Guid>? agentIds,
             string? cursor,
             string? durationMax,
             string? durationMin,
@@ -42,6 +44,7 @@ namespace Ultravox
         /// <summary>
         /// 
         /// </summary>
+        /// <param name="agentIds"></param>
         /// <param name="cursor"></param>
         /// <param name="durationMax"></param>
         /// <param name="durationMin"></param>
@@ -55,6 +58,7 @@ namespace Ultravox
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::Ultravox.ApiException"></exception>
         public async global::System.Threading.Tasks.Task<global::Ultravox.PaginatedCallList> CallsListAsync(
+            global::System.Collections.Generic.IList<global::System.Guid>? agentIds = default,
             string? cursor = default,
             string? durationMax = default,
             string? durationMin = default,
@@ -71,6 +75,7 @@ namespace Ultravox
                 client: HttpClient);
             PrepareCallsListArguments(
                 httpClient: HttpClient,
+                agentIds: agentIds,
                 cursor: ref cursor,
                 durationMax: ref durationMax,
                 durationMin: ref durationMin,
@@ -86,6 +91,7 @@ namespace Ultravox
                 path: "/api/calls",
                 baseUri: HttpClient.BaseAddress); 
             __pathBuilder 
+                .AddOptionalParameter("agentIds", agentIds, selector: static x => x.ToString(), delimiter: ",", explode: true) 
                 .AddOptionalParameter("cursor", cursor) 
                 .AddOptionalParameter("durationMax", durationMax) 
                 .AddOptionalParameter("durationMin", durationMin) 
@@ -128,6 +134,7 @@ namespace Ultravox
             PrepareCallsListRequest(
                 httpClient: HttpClient,
                 httpRequestMessage: __httpRequest,
+                agentIds: agentIds,
                 cursor: cursor,
                 durationMax: durationMax,
                 durationMin: durationMin,

--- a/src/libs/Ultravox/Generated/Ultravox.DeletedCallsClient.DeletedCallsList.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.DeletedCallsClient.DeletedCallsList.g.cs
@@ -7,6 +7,7 @@ namespace Ultravox
     {
         partial void PrepareDeletedCallsListArguments(
             global::System.Net.Http.HttpClient httpClient,
+            global::System.Collections.Generic.IList<global::System.Guid>? agentIds,
             ref string? cursor,
             ref string? durationMax,
             ref string? durationMin,
@@ -19,6 +20,7 @@ namespace Ultravox
         partial void PrepareDeletedCallsListRequest(
             global::System.Net.Http.HttpClient httpClient,
             global::System.Net.Http.HttpRequestMessage httpRequestMessage,
+            global::System.Collections.Generic.IList<global::System.Guid>? agentIds,
             string? cursor,
             string? durationMax,
             string? durationMin,
@@ -40,6 +42,7 @@ namespace Ultravox
         /// <summary>
         /// 
         /// </summary>
+        /// <param name="agentIds"></param>
         /// <param name="cursor"></param>
         /// <param name="durationMax"></param>
         /// <param name="durationMin"></param>
@@ -52,6 +55,7 @@ namespace Ultravox
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::Ultravox.ApiException"></exception>
         public async global::System.Threading.Tasks.Task<global::Ultravox.PaginatedCallTombstoneList> DeletedCallsListAsync(
+            global::System.Collections.Generic.IList<global::System.Guid>? agentIds = default,
             string? cursor = default,
             string? durationMax = default,
             string? durationMin = default,
@@ -67,6 +71,7 @@ namespace Ultravox
                 client: HttpClient);
             PrepareDeletedCallsListArguments(
                 httpClient: HttpClient,
+                agentIds: agentIds,
                 cursor: ref cursor,
                 durationMax: ref durationMax,
                 durationMin: ref durationMin,
@@ -81,6 +86,7 @@ namespace Ultravox
                 path: "/api/deleted_calls",
                 baseUri: HttpClient.BaseAddress); 
             __pathBuilder 
+                .AddOptionalParameter("agentIds", agentIds, selector: static x => x.ToString(), delimiter: ",", explode: true) 
                 .AddOptionalParameter("cursor", cursor) 
                 .AddOptionalParameter("durationMax", durationMax) 
                 .AddOptionalParameter("durationMin", durationMin) 
@@ -122,6 +128,7 @@ namespace Ultravox
             PrepareDeletedCallsListRequest(
                 httpClient: HttpClient,
                 httpRequestMessage: __httpRequest,
+                agentIds: agentIds,
                 cursor: cursor,
                 durationMax: durationMax,
                 durationMin: durationMin,

--- a/src/libs/Ultravox/Generated/Ultravox.IAccountsClient.AccountsMeUsageCallsRetrieve.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.IAccountsClient.AccountsMeUsageCallsRetrieve.g.cs
@@ -7,6 +7,7 @@ namespace Ultravox
         /// <summary>
         /// Gets aggregated call usage.
         /// </summary>
+        /// <param name="agentIds"></param>
         /// <param name="durationMax"></param>
         /// <param name="durationMin"></param>
         /// <param name="fromDate"></param>
@@ -17,6 +18,7 @@ namespace Ultravox
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::Ultravox.ApiException"></exception>
         global::System.Threading.Tasks.Task<global::Ultravox.CallUsage> AccountsMeUsageCallsRetrieveAsync(
+            global::System.Collections.Generic.IList<global::System.Guid>? agentIds = default,
             string? durationMax = default,
             string? durationMin = default,
             global::System.DateTime? fromDate = default,

--- a/src/libs/Ultravox/Generated/Ultravox.ICallsClient.CallsList.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.ICallsClient.CallsList.g.cs
@@ -7,6 +7,7 @@ namespace Ultravox
         /// <summary>
         /// 
         /// </summary>
+        /// <param name="agentIds"></param>
         /// <param name="cursor"></param>
         /// <param name="durationMax"></param>
         /// <param name="durationMin"></param>
@@ -20,6 +21,7 @@ namespace Ultravox
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::Ultravox.ApiException"></exception>
         global::System.Threading.Tasks.Task<global::Ultravox.PaginatedCallList> CallsListAsync(
+            global::System.Collections.Generic.IList<global::System.Guid>? agentIds = default,
             string? cursor = default,
             string? durationMax = default,
             string? durationMin = default,

--- a/src/libs/Ultravox/Generated/Ultravox.IDeletedCallsClient.DeletedCallsList.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.IDeletedCallsClient.DeletedCallsList.g.cs
@@ -7,6 +7,7 @@ namespace Ultravox
         /// <summary>
         /// 
         /// </summary>
+        /// <param name="agentIds"></param>
         /// <param name="cursor"></param>
         /// <param name="durationMax"></param>
         /// <param name="durationMin"></param>
@@ -19,6 +20,7 @@ namespace Ultravox
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::Ultravox.ApiException"></exception>
         global::System.Threading.Tasks.Task<global::Ultravox.PaginatedCallTombstoneList> DeletedCallsListAsync(
+            global::System.Collections.Generic.IList<global::System.Guid>? agentIds = default,
             string? cursor = default,
             string? durationMax = default,
             string? durationMin = default,

--- a/src/libs/Ultravox/Generated/Ultravox.JsonSerializerContextTypes.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.JsonSerializerContextTypes.g.cs
@@ -754,42 +754,46 @@ namespace Ultravox
         /// <summary>
         /// 
         /// </summary>
-        public global::Ultravox.AgentsScheduledBatchesScheduledCallsListStatus? Type182 { get; set; }
+        public global::System.Collections.Generic.IList<global::System.Guid>? Type182 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ultravox.CallsEventsListMinimumSeverity? Type183 { get; set; }
+        public global::Ultravox.AgentsScheduledBatchesScheduledCallsListStatus? Type183 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ultravox.CallsMessagesListMode? Type184 { get; set; }
+        public global::Ultravox.CallsEventsListMinimumSeverity? Type184 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ultravox.SchemaRetrieveFormat? Type185 { get; set; }
+        public global::Ultravox.CallsMessagesListMode? Type185 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ultravox.SchemaRetrieveLang? Type186 { get; set; }
+        public global::Ultravox.SchemaRetrieveFormat? Type186 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ultravox.VoicesListBillingStyle? Type187 { get; set; }
+        public global::Ultravox.SchemaRetrieveLang? Type187 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ultravox.VoicesListOwnership? Type188 { get; set; }
+        public global::Ultravox.VoicesListBillingStyle? Type188 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Ultravox.Account>? Type189 { get; set; }
+        public global::Ultravox.VoicesListOwnership? Type189 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Ultravox.CallTool>? Type190 { get; set; }
+        public global::System.Collections.Generic.IList<global::Ultravox.Account>? Type190 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Ultravox.UltravoxV1CorpusQueryResult>? Type191 { get; set; }
+        public global::System.Collections.Generic.IList<global::Ultravox.CallTool>? Type191 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::System.Collections.Generic.IList<global::Ultravox.UltravoxV1CorpusQueryResult>? Type192 { get; set; }
     }
 }

--- a/src/libs/Ultravox/Generated/Ultravox.Models.Call.g.cs
+++ b/src/libs/Ultravox/Generated/Ultravox.Models.Call.g.cs
@@ -207,6 +207,13 @@ namespace Ultravox
         public string? Summary { get; set; }
 
         /// <summary>
+        /// The ID of the agent used for this call.<br/>
+        /// Included only in responses
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("agentId")]
+        public string? AgentId { get; set; }
+
+        /// <summary>
         /// Experimental settings for the call.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("experimentalSettings")]
@@ -335,6 +342,10 @@ namespace Ultravox
         /// A summary of the call.<br/>
         /// Included only in responses
         /// </param>
+        /// <param name="agentId">
+        /// The ID of the agent used for this call.<br/>
+        /// Included only in responses
+        /// </param>
         /// <param name="experimentalSettings">
         /// Experimental settings for the call.
         /// </param>
@@ -378,6 +389,7 @@ namespace Ultravox
             global::Ultravox.UltravoxV1VadSettings? vadSettings,
             string? shortSummary,
             string? summary,
+            string? agentId,
             global::Ultravox.UltravoxV1DataConnectionConfig? dataConnectionConfig,
             global::System.Guid callId = default!,
             global::System.DateTime created = default!,
@@ -414,6 +426,7 @@ namespace Ultravox
             this.VadSettings = vadSettings;
             this.ShortSummary = shortSummary;
             this.Summary = summary;
+            this.AgentId = agentId;
             this.DataConnectionConfig = dataConnectionConfig;
         }
 

--- a/src/libs/Ultravox/openapi.yaml
+++ b/src/libs/Ultravox/openapi.yaml
@@ -180,6 +180,14 @@ paths:
       description: Gets aggregated call usage.
       operationId: accounts_me_usage_calls_retrieve
       parameters:
+        - name: agentIds
+          in: query
+          description: Filter calls by the agent IDs.
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
         - name: durationMax
           in: query
           description: Maximum duration of calls
@@ -748,6 +756,14 @@ paths:
         - calls
       operationId: calls_list
       parameters:
+        - name: agentIds
+          in: query
+          description: Filter calls by the agent IDs.
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
         - name: cursor
           in: query
           description: The pagination cursor value.
@@ -1603,6 +1619,14 @@ paths:
         - deleted_calls
       operationId: deleted_calls_list
       parameters:
+        - name: agentIds
+          in: query
+          description: Filter calls by the agent IDs.
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
         - name: cursor
           in: query
           description: The pagination cursor value.
@@ -2680,6 +2704,7 @@ components:
           format: double
     Call:
       required:
+        - agentId
         - billedDuration
         - callId
         - clientVersion
@@ -2819,6 +2844,11 @@ components:
         summary:
           type: string
           description: A summary of the call.
+          nullable: true
+          readOnly: true
+        agentId:
+          type: string
+          description: The ID of the agent used for this call.
           nullable: true
           readOnly: true
         experimentalSettings:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent-based filtering for call APIs via an agentIds query parameter (UUID array) on:
    * GET /api/accounts/me/usage/calls
    * GET /api/calls
    * GET /api/deleted_calls
  * Call responses now include an agentId field indicating the associated agent.
    * Field is read-only, nullable, and included as a required property in the schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->